### PR TITLE
Update sksat/action-clippy to v1.1.1

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -63,7 +63,7 @@ jobs:
         run: cargo fmt -- --check
 
       - name: reviewdog / clippy
-        uses: sksat/action-clippy@v0.7.1
+        uses: sksat/action-clippy@v1.1.1
         with:
           working_directory: ${{ matrix.workspace }}
 


### PR DESCRIPTION
In my fork, upgrading to `sksat/action-clippy@v1.1.1` appears to resolve the failures in the Clippy step. If the version was intentionally pinned for any reason, please feel free to close this PR.

<details>
<summary>CI screenshot in my fork</summary>

**pull request**

<img width="1633" height="1014" alt="image" src="https://github.com/user-attachments/assets/f7a2d6a3-6b17-498f-957c-22ec9518cb85" />

**CI after merge**

<img width="1474" height="1384" alt="image" src="https://github.com/user-attachments/assets/7a060bb9-7252-48e5-b34a-9f692ed1f162" />

</details>