### PR TITLE
fix the ringbuf's empty slice

### DIFF
--- a/ringbuf/src/lib.rs
+++ b/ringbuf/src/lib.rs
@@ -57,9 +57,9 @@ impl<'a> RingBuf<'a> {
     #[must_use]
     pub fn readable(&self) -> (&[u8], &[u8]) {
         if self.is_empty() {
-            (&[], &[])
+            (&self.buffer[..0], &self.buffer[..0])
         } else if self.front < self.back {
-            (&self.buffer[self.front..self.back], &[])
+            (&self.buffer[self.front..self.back], &self.buffer[..0])
         } else {
             (&self.buffer[self.front..], &self.buffer[..self.back])
         }


### PR DESCRIPTION
UARTのtxが出力されないエラーが発生したため対応。
原因は空スライス (&[]) に対して  `as_ptr()` を使用した際の返り値が toolchain バージョンによって異なるためで、DMAが `0x01` にアクセスしようとしてエラーが発生していた。
(`0x01`はITCM領域であり、DMAはアクセスできない)

- ~1.78.0：Flash領域のアドレスを返す
- 1.79.0~：バイト数を返す (今回のケースではu8なので`as_ptr()`は `0x01` を返す)

`Ringbuf.buffer`はFlash領域に配置されることを期待してよいため、`&self.buffer[..0]` を返すように変更。
変更後にdma送信割り込みが実行されるようになったことを確認した。

@KOBA789 
情報までにこちら対応完了したため、昨日お話ししていた通りこのままマージします。
